### PR TITLE
Fix duplicate running "xlnetacc.sh" issue

### DIFF
--- a/package/lean/luci-app-xlnetacc/root/etc/hotplug.d/iface/95-xlnetacc
+++ b/package/lean/luci-app-xlnetacc/root/etc/hotplug.d/iface/95-xlnetacc
@@ -5,7 +5,7 @@
 
 case "$ACTION" in
 	ifup)
-		/etc/init.d/xlnetacc start
+		/etc/init.d/xlnetacc restart
 		;;
 	ifdown)
 		/etc/init.d/xlnetacc stop


### PR DESCRIPTION
In some special cases, "xlnetacc" service might be started twice. For example, xlnetacc service starts at system boot stage and then starts again because of hotplug event (i.e. pppoe links up). This change makes sure "xlnetacc" service is stopped before it's started by hotplug event again.