### PR TITLE
Update Makefile

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -12,8 +12,8 @@ PKG_VERSION:=1.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.us.tcpdump.org/release/ \
-        http://www.tcpdump.org/release/
+PKG_SOURCE_URL:=http://www.tcpdump.org/release/
+        
 PKG_HASH:=2edb88808e5913fdaa8e9c1fcaf272e19b2485338742b5074b9fe44d68f37019
 PKG_FIXUP:=patch-libtool
 


### PR DESCRIPTION
The original link has expired, resulting in downloading the wrong version of the installation package.